### PR TITLE
Add Devtodev sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Wave Engine](https://waveengine.net/Engine) - Wave engine is a free c# component-based modern game engine which allows you to create cross-platform games supporting kinect, oculusrift, vuforia, cardboard, leapmotion and much more. **[Free][Proprietary]**
 * [UrhoSharp](https://github.com/xamarin/urho) - UrhoSharp is a C# implementation of the Urho3D game engine that runs on iOS, Mac, Windows, Android and Linux systems
 * [Nez](https://github.com/prime31/Nez) - Nez is a free 2D focused framework that works with MonoGame and FNA
+* [Devtodev](https://github.com/devtodev-analytics/winstore-sdk) - A full-cycle analytics solution for game developers.
 
 ## Gis
 


### PR DESCRIPTION
Game/Devtodev - [https://github.com/devtodev-analytics/winstore-sdk](https://github.com/devtodev-analytics/winstore-sdk)

devtodev (https://www.devtodev.com/) is an analytical platform developed by games industry professionals specifically for game developers. With devtodev, you can convert players into paying users, improve in-game economics, predict churn, revenue and customer lifetime value, as well as analyze and influence user behavior.
